### PR TITLE
[Re-request][Feature] Add support for multi-task CD models

### DIFF
--- a/paddlers/custom_models/cd/models/backbones/resnet.py
+++ b/paddlers/custom_models/cd/models/backbones/resnet.py
@@ -36,6 +36,7 @@ import paddle.nn as nn
 
 from paddle.utils.download import get_weights_path_from_url
 
+
 __all__ = []
 
 model_urls = {

--- a/paddlers/custom_models/cd/models/bit.py
+++ b/paddlers/custom_models/cd/models/bit.py
@@ -17,7 +17,6 @@ import paddle.nn as nn
 import paddle.nn.functional as F
 from paddle.nn.initializer import Normal
 
-
 from .backbones import resnet
 from .layers import Conv3x3, Conv1x1, get_norm_layer, Identity
 from .param_init import KaimingInitMixin
@@ -182,7 +181,7 @@ class BIT(nn.Layer):
 
         # Classifier forward
         pred = self.conv_out(y)
-        return pred,
+        return [pred]
 
     def init_weight(self):
         # Use the default initialization method.

--- a/paddlers/custom_models/cd/models/dsamnet.py
+++ b/paddlers/custom_models/cd/models/dsamnet.py
@@ -16,7 +16,6 @@ import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 
-
 from .layers import make_norm, Conv3x3, CBAM
 from .stanet import Backbone, Decoder
 
@@ -76,10 +75,12 @@ class DSAMNet(nn.Layer):
         out = F.interpolate(out, size=paddle.shape(t1)[2:], mode='bilinear', align_corners=True)
         pred = self.conv_out(out)
 
-        ds2 = self.dsl2(paddle.abs(f1[0]-f2[0]))
-        ds3 = self.dsl3(paddle.abs(f1[1]-f2[1]))
-
-        return pred, ds2, ds3
+        if not self.training:
+            return [pred]
+        else:
+            ds2 = self.dsl2(paddle.abs(f1[0]-f2[0]))
+            ds3 = self.dsl3(paddle.abs(f1[1]-f2[1]))
+            return [pred, ds2, ds3]
 
     def init_weight(self):
         pass

--- a/paddlers/custom_models/cd/models/layers/attention.py
+++ b/paddlers/custom_models/cd/models/layers/attention.py
@@ -16,7 +16,6 @@ import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 
-
 from .blocks import Conv1x1, BasicConv
 
 

--- a/paddlers/custom_models/cd/models/snunet.py
+++ b/paddlers/custom_models/cd/models/snunet.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
-
 
 from .layers import Conv1x1, MaxPool2x2, make_norm, ChannelAttention
 from .param_init import KaimingInitMixin
@@ -116,7 +114,7 @@ class SNUNet(nn.Layer, KaimingInitMixin):
         out = self.ca_inter(out) * (out + paddle.tile(m_intra, (1,4,1,1)))
 
         pred = self.conv_out(out)
-        return pred,
+        return [pred]
 
 
 class ConvBlockNested(nn.Layer):

--- a/paddlers/custom_models/cd/models/stanet.py
+++ b/paddlers/custom_models/cd/models/stanet.py
@@ -16,7 +16,6 @@ import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 
-
 from .backbones import resnet
 from .layers import Conv1x1, Conv3x3, get_norm_layer, Identity
 from .param_init import KaimingInitMixin
@@ -76,7 +75,7 @@ class STANet(nn.Layer):
         y = F.interpolate(y, size=paddle.shape(t1)[2:], mode='bilinear', align_corners=True)
 
         pred = self.conv_out(y)
-        return pred,
+        return [pred]
 
     def init_weight(self):
         # Do nothing here as the encoder and decoder weights have already been initialized.

--- a/paddlers/custom_models/cd/models/unet_ef.py
+++ b/paddlers/custom_models/cd/models/unet_ef.py
@@ -16,7 +16,6 @@ import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 
-
 from .layers import Conv3x3, MaxPool2x2, ConvTransposed3x3, Identity
 from .param_init import normal_init, constant_init
 
@@ -184,7 +183,7 @@ class UNetEarlyFusion(nn.Layer):
         x12d = self.do12d(self.conv12d(x1d))
         x11d = self.conv11d(x12d)
 
-        return x11d,
+        return [x11d]
 
     def init_weight(self):
         for sublayer in self.sublayers():

--- a/paddlers/custom_models/cd/models/unet_siamconc.py
+++ b/paddlers/custom_models/cd/models/unet_siamconc.py
@@ -16,7 +16,6 @@ import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 
-
 from .layers import Conv3x3, MaxPool2x2, ConvTransposed3x3, Identity
 from .param_init import normal_init, constant_init
 
@@ -207,7 +206,7 @@ class UNetSiamConc(nn.Layer):
         x12d = self.do12d(self.conv12d(x1d))
         x11d = self.conv11d(x12d)
 
-        return x11d,
+        return [x11d]
 
     def init_weight(self):
         for sublayer in self.sublayers():

--- a/paddlers/custom_models/cd/models/unet_siamdiff.py
+++ b/paddlers/custom_models/cd/models/unet_siamdiff.py
@@ -16,7 +16,6 @@ import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 
-
 from .layers import Conv3x3, MaxPool2x2, ConvTransposed3x3, Identity
 from .param_init import normal_init, constant_init
 
@@ -207,7 +206,7 @@ class UNetSiamDiff(nn.Layer):
         x12d = self.do12d(self.conv12d(x1d))
         x11d = self.conv11d(x12d)
 
-        return x11d,
+        return [x11d]
 
     def init_weight(self):
         for sublayer in self.sublayers():

--- a/paddlers/tasks/utils/seg_metrics.py
+++ b/paddlers/tasks/utils/seg_metrics.py
@@ -26,6 +26,17 @@ def loss_computation(logits_list, labels, losses):
     return loss_list
 
 
+def multitask_loss_computation(logits_list, labels_list, losses):
+    loss_list = []
+    for i in range(len(logits_list)):
+        logits = logits_list[i]
+        labels = labels_list[i]
+        loss_i = losses['types'][i]
+        loss_list.append(losses['coef'][i] * loss_i(logits, labels))
+
+    return loss_list
+
+
 def f1_score(intersect_area, pred_area, label_area):
     intersect_area = intersect_area.numpy()
     pred_area = pred_area.numpy()


### PR DESCRIPTION
Part 1 of #18 .

1. The new `multitask_loss_computation` function calculates the losses between multiple output logits and multiple masks.
2. The new field `aux_masks` in the sample dict is given such a name that it can be used for different tasks. For example, an edge mask can be stored as a `aux_mask` and used in a semantic segmentation task. Transformation operations on `aux_masks` have been supported.
3. A new protocol has been proposed for multi-task CD models. To enable the feature of multi-task training, an `nn.Layer` object should have an attribute named `USE_MULTITASK_DECODER` and set the value of it to `True`. Also, the object should have an attribute named `OUT_TYPES`, which is a tuple containing `LabelType` enums, each element in this tuple denoting the label type of the corresponding element in the output list of the `forward` method during model training.
4. Now `CDDataset` accepts an optional argument `with_seg_labels` and supports either 3 or 5 items in a line of the `file_list`.