### PR TITLE
[Feature] add slide-infer with geo-image (segmentation now)

### DIFF
--- a/paddlers/tasks/slider/__init__.py
+++ b/paddlers/tasks/slider/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .infer import SegSlider

--- a/paddlers/tasks/slider/infer/__init__.py
+++ b/paddlers/tasks/slider/infer/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .seginfer import SegSlider

--- a/paddlers/tasks/slider/infer/baseinfer.py
+++ b/paddlers/tasks/slider/infer/baseinfer.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from paddle.nn import Layer
+from paddlers.transforms.operators import Transform
+from typing import List, Union
+
+
+class BaseSlider(object):
+    def __init__(self, model: Layer,
+                 transforms: Union[Transform, None]=None) -> None:
+        self.model = model
+        self.model.eval()
+        self.transforms = transforms
+        self.ready()
+
+    def __call__(self) -> None:
+        raise NotImplementedError()
+
+    def ready(self, block_size: Union[List[int], int]=512) -> None:
+        self.block_size = block_size

--- a/paddlers/tasks/slider/infer/seginfer.py
+++ b/paddlers/tasks/slider/infer/seginfer.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os.path as osp
+import paddle
+from paddle.nn import Layer
+from paddlers.transforms.operators import Transform
+from tqdm import tqdm
+from typing import List, Union
+from .baseinfer import BaseSlider
+from ..io import RasterLoader, SegWriter
+
+
+class SegSlider(BaseSlider):
+    def __init__(self, model: Layer,
+                 transforms: Union[Transform, None]=None) -> None:
+        """ Slide infer about segmentation.
+
+        Args:
+            model (Layer): Model of PaddleRS.
+            transforms (Transform or None, optional): PaddleRS's transform. Defaults to None.
+        """
+        super(SegSlider, self).__init__(model, transforms)
+
+    def __call__(self, path: str) -> None:
+        dataloader = RasterLoader(path, self.block_size, self.overlap,
+                                  self.transforms)
+        datawriter = SegWriter(dataloader.config)
+        for data in tqdm(dataloader):
+            img = data["block"]
+            start = data["start"]
+            img = paddle.to_tensor(img.transpose((2, 0, 1))[None])
+            with paddle.no_grad():
+                pred = self.model(img)[0]
+            block = paddle.argmax(
+                pred, axis=1).squeeze().numpy().astype("uint8")
+            datawriter.write(block, start)
+        datawriter.close()
+        print("[Finshed] The file saved {0}.".format(
+            osp.normpath(datawriter.save_path)))
+
+    def ready(self,
+              block_size: Union[List[int], int]=512,
+              overlap: Union[List[int], int]=32) -> None:
+        """ Ready.
+
+        Args:
+            block_size (Union[List[int], int], optional): Size of image's block. Defaults to 512.
+            overlap (Union[List[int], int], optional): Overlap between two images. Defaults to 32.
+        """
+        super(SegSlider, self).ready(block_size)
+        self.overlap = overlap

--- a/paddlers/tasks/slider/io/__init__.py
+++ b/paddlers/tasks/slider/io/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .rasterloader import RasterLoader
+from .writer import SegWriter

--- a/paddlers/tasks/slider/io/rasterloader.py
+++ b/paddlers/tasks/slider/io/rasterloader.py
@@ -63,7 +63,6 @@ class RasterLoader(object):
                 format(len(self.block_size), len(self.overlap)))
         self.transforms = []
         for op in transforms.transforms:
-            print(op.__class__.__name__)
             if op.__class__.__name__ in self.TS:
                 self.transforms.append(op)
         if len(self.transforms) >= 1:

--- a/paddlers/tasks/slider/io/rasterloader.py
+++ b/paddlers/tasks/slider/io/rasterloader.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import paddlers.transforms as T
+from paddlers.transforms.operators import Transform
+from paddlers.transforms.functions import to_intensity
+from typing import List, Dict, Union
+
+try:
+    from osgeo import gdal
+except:
+    import gdal
+
+
+class RasterLoader(object):
+    TS = [
+        "Normalize", "RandomBlur", "Defogging", "DimReducing", "BandSelecting"
+    ]
+
+    def __init__(self,
+                 path: str,
+                 block_size: Union[List[int], int]=512,
+                 overlap: Union[List[int], int]=32,
+                 transforms: Union[Transform, None]=None) -> None:
+        """ Dataloadr about geo-raster.
+
+        Args:
+            path (str): Path of big-geo-image.
+            block_size (Union[List[int], int], optional): Size of image's block. Defaults to 512.
+            overlap (Union[List[int], int], optional): Overlap between two blocks. Defaults to 32.
+            transforms (Transform or None, optional): PaddleRS's transform. Defaults to None.
+
+        Raises:
+            ValueError: Can't read iamge from this path. 
+        """
+        self._src_data = gdal.Open(path)
+        if self._src_data is None:
+            raise ValueError("Can't read iamge from file {0}.".format(path))
+        self.path = path
+        if isinstance(block_size, int):
+            self.block_size = [block_size, block_size]
+        else:
+            self.block_size = list(block_size)
+        if isinstance(overlap, int):
+            self.overlap = [overlap, overlap]
+        else:
+            self.overlap = list(overlap)
+        if len(self.block_size) != 2 or len(self.overlap) != 2:
+            raise IndexError(
+                "Lenght of `block_size`/`overlap` must be 2, not {0}/{1}.".
+                format(len(self.block_size), len(self.overlap)))
+        self.transforms = []
+        for op in transforms.transforms:
+            print(op.__class__.__name__)
+            if op.__class__.__name__ in self.TS:
+                self.transforms.append(op)
+        if len(self.transforms) >= 1:
+            self.transforms = T.Compose(self.transforms)
+        else:
+            self.transforms = None
+        self.transforms.apply_im_only = True
+        self.__getInfos()
+        self.__getStart()
+
+    def __getitem__(self, index) -> np.ndarray:
+        start_loc = self._start_list[index]
+        return self.__getBlock(start_loc)
+
+    def __len__(self) -> int:
+        return len(self._start_list)
+
+    @property
+    def config(self) -> Dict:
+        return {
+            "file_path": self.path,
+            "width": self.width,
+            "height": self.height,
+            "proj": self.proj,
+            "geotf": self.geotf,
+            "block_size": self.block_size,
+            "overlap": self.overlap,
+            "num_block": self.__len__,
+        }
+
+    def __getInfos(self) -> None:
+        self.bands = self._src_data.RasterCount
+        self.width = self._src_data.RasterXSize
+        self.height = self._src_data.RasterYSize
+        self.geotf = self._src_data.GetGeoTransform()
+        self.proj = self._src_data.GetProjection()
+
+    def __getStart(self) -> None:
+        self._start_list = []
+        step_r = self.block_size[1] - self.overlap[1]
+        step_c = self.block_size[0] - self.overlap[0]
+        for r in range(0, self.height, step_r):
+            for c in range(0, self.width, step_c):
+                self._start_list.append([c, r])
+
+    def __preProcessing(self, im: np.ndarray) -> np.ndarray:
+        if im.ndim == 2:
+            im = to_intensity(im)  # is read SAR
+            im = im[:, :, np.newaxis]
+        elif im.ndim == 3:
+            im = im.transpose((1, 2, 0))
+        if self.transforms is not None:
+            data = {"image": im}
+            im = self.transforms(data)["image"]
+        return im
+
+    def __getBlock(self, start_loc: List[int]) -> np.ndarray:
+        xoff, yoff = start_loc
+        xsize, ysize = self.block_size
+        if xoff + xsize > self.width:
+            xsize = self.width - xoff
+        if yoff + ysize > self.height:
+            ysize = self.height - yoff
+        im = self._src_data.ReadAsArray(
+            int(xoff), int(yoff), int(xsize), int(ysize))
+        im = self.__preProcessing(im)
+        h, w = im.shape[:2]
+        out = np.zeros(
+            (self.block_size[1], self.block_size[0], self.bands),
+            dtype=im.dtype)
+        out[:h, :w, :] = im
+        return {"block": out, "start": start_loc}

--- a/paddlers/tasks/slider/io/writer/__init__.py
+++ b/paddlers/tasks/slider/io/writer/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .segwriter import SegWriter

--- a/paddlers/tasks/slider/io/writer/base.py
+++ b/paddlers/tasks/slider/io/writer/base.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os.path as osp
+from typing import Dict
+
+
+class BaseWriter(object):
+    def __init__(self, config: Dict, ext: str="tif") -> None:
+        file_split = osp.split(config["file_path"])
+        self.save_path = osp.join(
+            file_split[0], osp.splitext(file_split[-1])[0] + "_output." + ext)
+        self.width = config["width"]
+        self.height = config["height"]
+        self.proj = config["proj"]
+        self.geotf = config["geotf"]
+        self.block_size = config["block_size"]
+        self.overlap = config["overlap"]
+        self.num_block = config["num_block"]
+
+    def write(self) -> None:
+        raise NotImplementedError
+
+    def close(self) -> None:
+        raise NotImplementedError

--- a/paddlers/tasks/slider/io/writer/segwriter.py
+++ b/paddlers/tasks/slider/io/writer/segwriter.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+from typing import List, Dict
+from .base import BaseWriter
+
+try:
+    from osgeo import gdal
+except:
+    import gdal
+
+
+class SegWriter(BaseWriter):
+    def __init__(self, config: Dict) -> None:
+        super(SegWriter, self).__init__(config, "tif")
+        driver = gdal.GetDriverByName("GTiff")
+        self.dst_ds = driver.Create(self.save_path, self.width, self.height, 1,
+                                    gdal.GDT_UInt16)
+        self.dst_ds.SetGeoTransform(self.geotf)
+        self.dst_ds.SetProjection(self.proj)
+        self.band = self.dst_ds.GetRasterBand(1)
+        self.band.WriteArray(255 * np.ones(
+            (self.height, self.width), dtype="uint8"))
+
+    def write(self, block: np.ndarray, start: List[int]) -> None:
+        bw, bh = self.block_size
+        xoff, yoff = start
+        xsize = xoff + bw
+        ysize = yoff + bh
+        xsize = int(self.width - xoff) if xsize > self.width else int(bw)
+        ysize = int(self.height - yoff) if ysize > self.height else int(bh)
+        rd_block = self.band.ReadAsArray(int(xoff), int(yoff), xsize, ysize)
+        h, w = rd_block.shape
+        mask = (rd_block == block[:h, :w]) | (rd_block == 255)
+        temp = block[:h, :w].copy()
+        temp[mask == False] = 0
+        self.band.WriteArray(temp, int(xoff), int(yoff))
+        self.dst_ds.FlushCache()
+
+    def close(self) -> None:
+        self.dst_ds = None


### PR DESCRIPTION
从之前的项目[https://github.com/geoyee/SlideInfer](https://github.com/geoyee/SlideInfer)先改了seg的过来，如果ok的话再把det之类的移过来。功能就是读一张很大的图然后滑框预测，将结果保存为tiff。这里的给的`transforms`主要是对图像块做normal、blur之类的非几何变换。后面还有参数就是滑框的大小和重叠区域的大小。

``` python
import paddlers as pdrs
from paddlers import transforms as T

train_transforms = T.Compose([
    T.Resize(target_size=512),
    T.RandomHorizontalFlip(prob=0.5),
    T.Normalize(
        mean=[0.5] * NUM_BANDS, std=[0.5] * NUM_BANDS),
])

eval_transforms = T.Compose([
    T.Resize(target_size=512),
    T.Normalize(
        mean=[0.5] * NUM_BANDS, std=[0.5] * NUM_BANDS),
])

train_dataset = pdrs.datasets.SegDataset(
    data_dir=DATA_DIR,
    file_list=TRAIN_FILE_LIST_PATH,
    label_list=LABEL_LIST_PATH,
    transforms=train_transforms,
    num_workers=0,
    shuffle=True)

eval_dataset = pdrs.datasets.SegDataset(
    data_dir=DATA_DIR,
    file_list=EVAL_FILE_LIST_PATH,
    label_list=LABEL_LIST_PATH,
    transforms=eval_transforms,
    num_workers=0,
    shuffle=False)

model = pdrs.tasks.UNet(
    input_channel=NUM_BANDS, num_classes=len(train_dataset.labels))

model.train(
    num_epochs=10,
    train_dataset=train_dataset,
    train_batch_size=2,
    eval_dataset=eval_dataset,
    save_interval_epochs=2,
    log_interval_steps=10,
    save_dir=EXP_DIR,
    learning_rate=0.0001,
    early_stop=False,
    use_vdl=True,
    resume_checkpoint=None)

# 只需要这样使用
model.geo_infer(
    IMG_PATH,
    eval_transforms
)
```