### PR TITLE
[Feat] Update use mixed loss

### DIFF
--- a/paddlers/tasks/change_detector.py
+++ b/paddlers/tasks/change_detector.py
@@ -830,9 +830,7 @@ class DSIFN(BaseChangeDetector):
                 'coef': [1.0] * 5
             }
         else:
-            raise ValueError(
-                f"Currently `use_mixed_loss` must be set to False for {self.__class__}"
-            )
+            return super().default_loss()
 
 
 class DSAMNet(BaseChangeDetector):
@@ -864,9 +862,7 @@ class DSAMNet(BaseChangeDetector):
                 'coef': [1.0, 0.05, 0.05]
             }
         else:
-            raise ValueError(
-                f"Currently `use_mixed_loss` must be set to False for {self.__class__}"
-            )
+            return super().default_loss()
 
 
 class ChangeStar(BaseChangeDetector):
@@ -898,6 +894,4 @@ class ChangeStar(BaseChangeDetector):
                 'coef': [1.0] * 4
             }
         else:
-            raise ValueError(
-                f"Currently `use_mixed_loss` must be set to False for {self.__class__}"
-            )
+            return super().default_loss()


### PR DESCRIPTION
1. 按照之前与 @LutaoChu 的商讨结果，修改了`Segmenter`与`ChangeDetector`的`use_mixed_loss`相关逻辑和接口。目前支持API调用者直接传入构建好的loss对象。为了让API使用起来更加便捷，支持传入布尔型、列表、字典、或者loss对象这四种不同的类型。
2. 目前所有的变化检测模型（包括使用了深度监督的模型和多任务模型）均已支持用户自定义的`use_mixed_loss`参数。

问题：目前的实现进一步复杂化了`use_mixed_loss`，加重了这个输入参数本来就存在的“名称与行为不一致”的问题。是否考虑拆成多个参数或者更名？