### PR TITLE
[Fix] Fix `Predictor.postprocess()` method for classification task

### DIFF
--- a/paddlers/tasks/base.py
+++ b/paddlers/tasks/base.py
@@ -614,7 +614,7 @@ class BaseModel(metaclass=ModelMeta):
         return pipeline_info
 
     def _build_inference_net(self):
-        if self.model_type == 'detector':
+        if self.model_type in ('classifier', 'detector'):
             infer_net = self.net
         elif self.model_type == 'changedetector':
             infer_net = InferCDNet(self.net)

--- a/paddlers/tasks/utils/infer_nets.py
+++ b/paddlers/tasks/utils/infer_nets.py
@@ -21,13 +21,10 @@ class PostProcessor(paddle.nn.Layer):
         self.model_type = model_type
 
     def forward(self, net_outputs):
-        if self.model_type == 'classifier':
-            outputs = paddle.nn.functional.softmax(net_outputs, axis=1)
-        else:
-            # label_map [NHW], score_map [NHWC]
-            logit = net_outputs[0]
-            outputs = paddle.argmax(logit, axis=1, keepdim=False, dtype='int32'), \
-                      paddle.transpose(paddle.nn.functional.softmax(logit, axis=1), perm=[0, 2, 3, 1])
+        # label_map [NHW], score_map [NHWC]
+        logit = net_outputs[0]
+        outputs = paddle.argmax(logit, axis=1, keepdim=False, dtype='int32'), \
+                    paddle.transpose(paddle.nn.functional.softmax(logit, axis=1), perm=[0, 2, 3, 1])
 
         return outputs
 


### PR DESCRIPTION
1. 修复了分类任务部署时的错误 #104 ；
2. 为`BaseClassifier`提供了新的接口`build_postprocess_from_labels()`供`Predictor`调用；
3. 原有的`BaseClassifier.predict()`方法具体功能与注释描述不一致，修复了此问题。